### PR TITLE
I18n

### DIFF
--- a/projects/toco-lib/src/lib/authentication/authentication.component.html
+++ b/projects/toco-lib/src/lib/authentication/authentication.component.html
@@ -3,7 +3,7 @@
     <mat-card fxLayoutAlign="center center" fxLayout="column">
 
         <mat-card-header>
-            <mat-card-title *ngIf="!userName">Autenticación con</mat-card-title>
+            <mat-card-title *ngIf="!userName">{{ 'TOCO_AUTHENTICATION.MAT_CARD_TITLE_AUTH' | translate }}</mat-card-title>
         </mat-card-header>
 
         <mat-card-content fxLayoutAlign="center center" fxLayout="column">
@@ -12,9 +12,9 @@
             </button>
 
             <ng-template #templateName>
-                <h1>Hola {{userName}}</h1>
+                <h1>{{ 'TOCO_AUTHENTICATION.H1_HOLA' | translate }} {{ userName }}</h1>
                 <button mat-raised-button color="primary" style="width: 12em" (click)="logoff()">
-                    Salir
+                    {{ 'TOCO_AUTHENTICATION.BUTTON_SALIR' | translate }}
                 </button>
             </ng-template>
 
@@ -23,11 +23,11 @@
 </div>
 
 <ng-template #template_buttonLogin>
-    <button  mat-icon-button *ngIf="isButtonLoginIcon" (click)="login()" matTooltip="{{isButtonLoginText}}">
+    <button *ngIf="isButtonLoginIcon" mat-icon-button (click)="login()" matTooltip="{{ isButtonLoginText }}">
         <mat-icon>lock_open</mat-icon>
     </button>
-    <button  mat-raised-button *ngIf="!isButtonLoginIcon" color="primary" (click)="login()">
-        {{isButtonLoginText}}
+    <button *ngIf="!isButtonLoginIcon" mat-raised-button color="primary" (click)="login()">
+        {{ isButtonLoginText }}
         <mat-icon class="mat-18">lock_open</mat-icon>
     </button>
 </ng-template>

--- a/projects/toco-lib/src/lib/authentication/authentication.component.ts
+++ b/projects/toco-lib/src/lib/authentication/authentication.component.ts
@@ -1,20 +1,18 @@
+
 import { AfterViewInit, Component, Input, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
-import {
-  AuthConfig, JwksValidationHandler, OAuthService,
-
-  OAuthStorage
-} from "angular-oauth2-oidc";
 import { PartialObserver, Subscription, timer } from "rxjs";
-import { UserProfileService } from "../backend/public-api";
+import { TranslateService } from "@ngx-translate/core";
+import { AuthConfig, JwksValidationHandler, OAuthService,OAuthStorage } from "angular-oauth2-oidc";
+
 import { Environment } from "../core/env";
-import { UserProfile } from "../entities/public-api";
+import { UserProfileService } from "../backend/user-profile.service";
+import { UserProfile } from "../entities/person.entity";
 import { OauthAuthenticationService } from "./authentication.service";
-
-
-
 // import { authConfig } from './auth-config';
-export interface OauthInfo{
+
+export interface OauthInfo
+{
   serverHost: string;
   loginUrl: string;
   tokenEndpoint: string;
@@ -25,6 +23,34 @@ export interface OauthInfo{
   oauthClientId: string;
   oauthScope: string;
 }
+
+/**
+ * Represents a component used to authenticate. 
+ * 
+ * In order to use this component with the correct i18n, you must include 
+ * (in your i18n translate files that are in the folder `assets\i18n`) 
+ * a translation key of name "TOCO_AUTHENTICATION" that contains 
+ * an object as value with the translation needed by this component. 
+ * 
+ * In the case of `es.json` file, you must include the following translation key: 
+    "TOCO_AUTHENTICATION": {
+        "MAT_CARD_TITLE_AUTH": "Autenticación con",
+        "AUTENTICARSE": "Autenticarse",
+        "H1_HOLA": "Hola",
+        "BUTTON_SALIR": "Salir"
+    }
+ * 
+ * In the case of `en.json` file, you must include the following translation key: 
+    "TOCO_AUTHENTICATION": {
+        "MAT_CARD_TITLE_AUTH": "Authentication with",
+        "AUTENTICARSE": "Log in",
+        "H1_HOLA": "Hello,",
+        "BUTTON_SALIR": "Exit"
+    }
+ * 
+ * If you have another language, then you have another `*.json` file, 
+ * and you must include the "TOCO_AUTHENTICATION" translation key with the correct translation values. 
+ */
 @Component({
   selector: "toco-authentication",
   templateUrl: "./authentication.component.html",
@@ -77,16 +103,24 @@ export class AuthenticationComponent implements OnInit, AfterViewInit {
   constructor(
     private userProfileService: UserProfileService,
     private env: Environment,
+    private router: Router,
     private oauthService: OAuthService,
     private oauthStorage: OAuthStorage,
     private authenticationService: OauthAuthenticationService,
-    private router: Router
-  ) {}
+    private _transServ: TranslateService
+  )
+  { }
 
-  ngOnInit() {
+  ngOnInit()
+  {
     if (this.isButtonLogin == undefined) this.isButtonLogin = false;
     if (this.isButtonLoginIcon == undefined) this.isButtonLoginIcon = false;
-    if (this.isButtonLoginText == undefined) this.isButtonLoginText = "Login";
+    if (this.isButtonLoginText == undefined)
+    {
+      this._transServ.get('TOCO_AUTHENTICATION.AUTENTICARSE').subscribe((res: string) => {
+        this.isButtonLoginText = res;
+      });
+    }
     if (this.oauthInfo.loginUrl == undefined || this.oauthInfo.loginUrl == ''){
       this.oauthInfo.loginUrl = this.oauthInfo.serverHost + "oauth/authorize";
     }
@@ -182,7 +216,7 @@ export class AuthenticationComponent implements OnInit, AfterViewInit {
         );
       },
       onLoginError: (err) => {
-        console.log("errorr in login", err);
+        console.log("error in login", err);
       },
     });
   }

--- a/projects/toco-lib/src/lib/authentication/authentication.module.ts
+++ b/projects/toco-lib/src/lib/authentication/authentication.module.ts
@@ -6,13 +6,13 @@
 
 import { NgModule } from '@angular/core';
 import { SharedModule } from '../shared/public-api';
-
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { TranslateModule } from '@ngx-translate/core';
 import { OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 
 import { AuthenticationComponent } from './authentication.component'
 import { AuthenticateRoutingModule } from './authentication-routing.module'
 import { OauthAuthenticationService, SimpleAuthenticationService } from './authentication.service'
-import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 
 export function storageFactory() : OAuthStorage {
   return localStorage
@@ -25,6 +25,7 @@ export function storageFactory() : OAuthStorage {
     imports: [
         SharedModule,
         HttpClientModule,
+        TranslateModule,
         OAuthModule.forRoot(),
         // AuthenticateRoutingModule
     ],

--- a/projects/toco-lib/src/lib/authentication/authentication.service.ts
+++ b/projects/toco-lib/src/lib/authentication/authentication.service.ts
@@ -12,8 +12,6 @@ import { catchError } from 'rxjs/operators';
 import { UserProfile } from '../../public-api';
 import { Environment } from '../core/public-api';
 
-
-
 /**
  * This enum handles the selected backend
  */
@@ -182,9 +180,4 @@ export class SimpleAuthenticationService { //implements CanActivate {
   //   }
 
   // }
-
-
-
-
 }
-

--- a/projects/toco-lib/src/lib/core/core.module.ts
+++ b/projects/toco-lib/src/lib/core/core.module.ts
@@ -21,7 +21,7 @@ import { RoadMapComponent } from './utils/road-map/road-map.component';
 import { RoadMapSceibaComponent } from './utils/road-map-sceiba/road-map-sceiba.component';
 import { GetViewContainerDirective } from './utils/get-view-container.directive';
 import { EqualLengthDirective } from './utils/validator';
-import { DialogContentComponent } from './utils/message-handler';
+import { DialogContentComponent, DialogDeleteConfirmComponent } from './utils/message-handler';
 import { ProgressComponent } from './utils/progress';
 import { SceibaAppsComponent } from './sceiba-apps/sceiba-apps.component';
 
@@ -40,6 +40,7 @@ import { SceibaAppsComponent } from './sceiba-apps/sceiba-apps.component';
         GetViewContainerDirective,
         EqualLengthDirective,
         DialogContentComponent,
+        DialogDeleteConfirmComponent,
         ProgressComponent,
         SceibaAppsComponent
     ],
@@ -65,11 +66,13 @@ import { SceibaAppsComponent } from './sceiba-apps/sceiba-apps.component';
         GetViewContainerDirective,
         EqualLengthDirective,
         DialogContentComponent,
+        DialogDeleteConfirmComponent,
         ProgressComponent,
         SceibaAppsComponent
     ],
     entryComponents: [
         DialogContentComponent,
+        DialogDeleteConfirmComponent
     ],
     providers: [
         MetadataService

--- a/projects/toco-lib/src/lib/core/core.module.ts
+++ b/projects/toco-lib/src/lib/core/core.module.ts
@@ -82,6 +82,6 @@ export class CoreModule
 {
     public constructor(@Optional() @SkipSelf() parentModule: CoreModule)
     {
-        throwIfAlreadyLoaded(parentModule, 'CoreModule');
+        //throwIfAlreadyLoaded(parentModule, 'CoreModule');
     }
 }

--- a/projects/toco-lib/src/lib/core/utils/helpers.ts
+++ b/projects/toco-lib/src/lib/core/utils/helpers.ts
@@ -21,10 +21,11 @@ export type Params<T> = {
 
 /**
  * An object of paths that is used to get the child controls in a `FormGroup`/`FormArray` control. 
- * The value of its properties is a dot-delimited string value that defines the path to a child control. 
+ * The value of its properties is a dot-delimited string value or an array of string/number values 
+ * that define the path to a child control. 
  */
 export type ChildControlsPath = {
-    [key: string]: string;
+    [key: string]: Array<string | number> | string;
 };
 
 /**

--- a/projects/toco-lib/src/lib/core/utils/helpers.ts
+++ b/projects/toco-lib/src/lib/core/utils/helpers.ts
@@ -21,7 +21,7 @@ export type Params<T> = {
 
 /**
  * An object of paths that is used to get the child controls in a `FormGroup`/`FormArray` control. 
- * The value of its properties is a dot-delimited string value that define the path to a child control. 
+ * The value of its properties is a dot-delimited string value that defines the path to a child control. 
  */
 export type ChildControlsPath = {
     [key: string]: string;

--- a/projects/toco-lib/src/lib/core/utils/helpers.ts
+++ b/projects/toco-lib/src/lib/core/utils/helpers.ts
@@ -20,6 +20,14 @@ export type Params<T> = {
 };
 
 /**
+ * An object of paths that is used to get the child controls in a `FormGroup`/`FormArray` control. 
+ * The value of its properties is a dot-delimited string value that define the path to a child control. 
+ */
+export type ChildControlsPath = {
+    [key: string]: string;
+};
+
+/**
  * Returns true if the specified `possDescendant` is descendant from the specified `ancestorName`; 
  * otherwise, false. 
  * @param possDescendant Possible descendant. 

--- a/projects/toco-lib/src/lib/core/utils/message-handler.ts
+++ b/projects/toco-lib/src/lib/core/utils/message-handler.ts
@@ -1,62 +1,138 @@
 
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { Component, Inject } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 export enum HandlerComponent {
-  snackBar = 'snackBar',
-  dialog = 'dialog',
+	snackBar = 'snackBar',
+	dialog = 'dialog',
 }
 
 export enum StatusCode {
-  OK = 200,
-  serverError = 500,
-  notFound = 400
+	OK = 200,
+	serverError = 500,
+	notFound = 400
 }
 
+/**
+ * Object that is used with the `DialogContentComponent` component. 
+ * It contains the data that are showed in the message. 
+ */
+export class DialogMessageData
+{
+    /**
+     * Message title. 
+     */
+	title: string;
+    /**
+     * Message content. 
+     */
+	content: string;
+}
 
+/**
+ * Object that is used with the `DialogDeleteConfirmComponent` component. 
+ * It contains the data that are showed in the message. 
+ */
+export class DialogDeleteConfirmMessageData
+{
+    /**
+     * Article of the type to delete. 
+     */
+	delTypeArt: string;
+    /**
+     * Type to delete. 
+     */
+	delType: string;
+    /**
+     * Value to delete. 
+     */
+	delValue: string;
+}
+
+/**
+ * Simple dialog message. 
+ */
 @Component({
-  selector: 'toco-dialog-message',
-  template: '<h2 mat-dialog-title>{{ data.title }}</h2> <mat-dialog-content> {{ data.content }} </mat-dialog-content> <mat-dialog-actions align="end"><button mat-button mat-dialog-close>OK</button> </mat-dialog-actions>',
+	selector: 'toco-dialog-message',
+	template: `
+		<h1 mat-dialog-title>
+			{{ data.title }}
+		</h1>
+		<mat-dialog-content> {{ data.content }} </mat-dialog-content>
+		<mat-dialog-actions align="end">
+			<button mat-button mat-dialog-close>OK</button>
+		</mat-dialog-actions>
+	`
 })
-export class DialogContentComponent {
-  constructor(@Inject(MAT_DIALOG_DATA) public data: any) { }
+export class DialogContentComponent
+{
+	public constructor(@Inject(MAT_DIALOG_DATA) public data: DialogMessageData)
+	{ }
 }
 
-export class MessageHandler {
+/**
+ * Dialog confirm message used to delete something. 
+ */
+@Component({
+	selector: 'toco-dialog-delete-confirm',
+	template: `
+		<h1 mat-dialog-title>
+			¿Está usted seguro que desea eliminar {{ data.delTypeArt }} <strong>{{ data.delType }}</strong>?
+		</h1>
+		<mat-dialog-content>
+			Su valor es: <em>{{ data.delValue }}</em>
+		</mat-dialog-content>
+		<mat-dialog-actions align="end">
+			<button mat-button mat-dialog-close color="warning">Cancelar</button>
+			<button mat-button [mat-dialog-close]="true" color="warning" cdkFocusInitial>Eliminar</button>
+		</mat-dialog-actions>
+	`
+})
+export class DialogDeleteConfirmComponent
+{
+	public constructor(
+		/*public dialogRef: MatDialogRef<DialogDeleteConfirmComponent>,*/
+		@Inject(MAT_DIALOG_DATA) public data: DialogDeleteConfirmMessageData)
+	{ }
+}
 
-  constructor(private _snackBar?: MatSnackBar, public dialog?: MatDialog) { }
+export class MessageHandler
+{
+	constructor(private _snackBar?: MatSnackBar, public dialog?: MatDialog)
+	{ }
 
-  showMessage(status: StatusCode, message?: string, component?: HandlerComponent, tilte?: string , width?: string ) {
-    switch (status) {
-      case StatusCode.serverError:
-        this.componentHandler(message ? message : 'No se pudo conectar al servidor', component, tilte, width);
-        break;
-      case StatusCode.notFound:
-        this.componentHandler(message ? message : 'Operación extraviada, no se pudo realizar', component, tilte, width);
-        break;
-      default:
-        this.componentHandler(message ? message : 'Operación realizada con éxito', component, tilte, width);
-        break;
-    }
-  }
+	showMessage(status: StatusCode, message?: string, component?: HandlerComponent, title?: string, width?: string) {
+		switch (status)
+		{
+			case StatusCode.serverError:
+				this.componentHandler(message ? message : 'No se pudo conectar al servidor.', component, title, width);
+				break;
+			case StatusCode.notFound:
+				this.componentHandler(message ? message : 'Operación extraviada, no se pudo realizar.', component, title, width);
+				break;
+			default:
+				this.componentHandler(message ? message : 'Operación realizada con éxito.', component, title, width);
+				break;
+		}
+	}
 
-  private componentHandler(message: string, handlercomponent?: HandlerComponent, tilte?: string , width: string = '300px' ): void {
-    switch (handlercomponent) {
-      case HandlerComponent.dialog:
-        this.dialog.open(DialogContentComponent, {
-          width: width,
-          data: {title: tilte, content: message}
-        });
-        break;
+	private componentHandler(message: string, handlercomponent?: HandlerComponent, title?: string, width: string = '300px'): void {
+		switch (handlercomponent)
+		{
+			case HandlerComponent.dialog:
+				this.dialog.open(DialogContentComponent, {
+					width: width,
+					data: { title: title, content: message }
+				});
+				break;
 
-      default:
-        this._snackBar.open(message, null, {
-          duration: 5000,
-          verticalPosition: 'bottom',
-        });
-        break;
-    }
-  }
-
+			default:
+				this._snackBar.open(message, null, {
+					duration: 5000,
+					verticalPosition: 'bottom',
+				});
+				break;
+		}
+	}
 }

--- a/projects/toco-lib/src/lib/core/utils/message-handler.ts
+++ b/projects/toco-lib/src/lib/core/utils/message-handler.ts
@@ -16,7 +16,7 @@ export enum StatusCode {
 
 /**
  * Object that is used with the `DialogContentComponent` component. 
- * It contains the data that are showed in the message. 
+ * It contains the different data that are showed in the message. 
  */
 export class DialogMessageData
 {
@@ -32,7 +32,7 @@ export class DialogMessageData
 
 /**
  * Object that is used with the `DialogDeleteConfirmComponent` component. 
- * It contains the data that are showed in the message. 
+ * It contains the different data that are showed in the message. 
  */
 export class DialogDeleteConfirmMessageData
 {
@@ -61,7 +61,7 @@ export class DialogDeleteConfirmMessageData
 		</h1>
 		<mat-dialog-content> {{ data.content }} </mat-dialog-content>
 		<mat-dialog-actions align="end">
-			<button mat-button mat-dialog-close>OK</button>
+			<button mat-stroked-button mat-dialog-close>OK</button>
 		</mat-dialog-actions>
 	`
 })
@@ -84,8 +84,8 @@ export class DialogContentComponent
 			Su valor es: <em>{{ data.delValue }}</em>
 		</mat-dialog-content>
 		<mat-dialog-actions align="end">
-			<button mat-button mat-dialog-close color="warning">Cancelar</button>
-			<button mat-button [mat-dialog-close]="true" color="warning" cdkFocusInitial>Eliminar</button>
+			<button mat-stroked-button mat-dialog-close color="warning">Cancelar</button>
+			<button mat-stroked-button [mat-dialog-close]="true" color="warning" cdkFocusInitial>Eliminar</button>
 		</mat-dialog-actions>
 	`
 })

--- a/projects/toco-lib/src/lib/core/utils/validator.ts
+++ b/projects/toco-lib/src/lib/core/utils/validator.ts
@@ -1,6 +1,6 @@
 
 import { Directive, OnChanges, Input, SimpleChanges } from '@angular/core';
-import { AbstractControl, FormControl, ValidatorFn, ValidationErrors, Validator, NG_VALIDATORS, FormGroup } from '@angular/forms';
+import { AbstractControl, FormControl, ValidatorFn, ValidationErrors, Validator, NG_VALIDATORS, FormGroup, FormArray } from '@angular/forms';
 
 /**
  * Represents a class that contains a boolean property named `required`. 
@@ -55,6 +55,38 @@ export class ExtraValidators
 
             return ((len != 0) && (len != equalLength)) 
                 ? { 'equalLength': { 'requiredLength': equalLength, 'actualLength': len } } 
+                : null;
+        };
+
+        return res;
+    }
+
+    /**
+     * @description
+     * Validator that is applied to `FormArray` controls. It requires that the amount of 
+	 * `FormArray`'s child controls to be greater than or equal to the provided minimum length. 
+	 * The validator exists only as a function and not as a directive. 
+     *
+     * @usageNotes
+     *
+     * ### Validates that the `FormArray` field has a minimum of 2 child controls: 
+     *
+     * ```typescript 
+     * const formArrayControl = new FormArray([new FormControl('ng')], ExtraValidators.minLength(2)); 
+     *
+	 * console.log(formArrayControl.errors); // { minLength: { requiredLength: 2, actualLength: 1 } } 
+     * ``` 
+     *
+     * @returns A validator function that returns an error map with the 
+     * `minLength` if the validation check fails, otherwise `null`. 
+     */
+    public static minLength(minLength: number): ValidatorFn
+    {
+        const res = (control: FormArray): ValidationErrors | null => {
+            const len: number = control.controls.length;
+
+            return (len < minLength) 
+                ? { 'minLength': { 'requiredLength': minLength, 'actualLength': len } } 
                 : null;
         };
 

--- a/projects/toco-lib/src/lib/entities/inst-repo.entity.ts
+++ b/projects/toco-lib/src/lib/entities/inst-repo.entity.ts
@@ -1,0 +1,63 @@
+
+import { EntityBase, Entity, Identifier } from './common';
+
+/**
+ * Entity for main Institution based on schema `...-v1.0.0.json`. 
+ */
+export class MainInstitution extends EntityBase
+{
+    /**
+     * The name typically used to refer to the institute. 
+     */
+    name: string;
+    /**
+     * Organization Identifiers, different from GRID mapping. 
+     */
+    identifiers: Array<Identifier>;
+}
+
+/**
+ * Entity for Institutional Repository based on schema `...-v1.0.0.json`. 
+ */
+export class InstitutionalRepository extends Entity
+{
+    /**
+     * Name of the region. 
+     */
+    name: string;
+    /**
+     * Main Institution. 
+     */
+    mainInst: MainInstitution;
+    /**
+     * URL page for the institute. 
+     */
+    url: string;
+    /**
+     * URL-OAI page for the institute. 
+     */
+    url_oai: string;
+}
+
+/**
+ * Represents an object of `MainInstitution` type with all its values set to empty. 
+ * The `identifiers` array field must have one empty value at least. 
+ */
+export const mainInstEmpty: any = {
+    'name': '',
+    'identifiers': [{
+        'idtype': '',
+        'value': ''
+    }]
+};
+
+/**
+ * Represents an object of `InstitutionalRepository` type with all its values set to empty. 
+ */
+export const instRepoEmpty: any = {
+    'id': '',
+    'name': '',
+    'mainInst': mainInstEmpty,
+    'url': '',
+    'url_oai': ''
+};

--- a/projects/toco-lib/src/lib/entities/public-api.ts
+++ b/projects/toco-lib/src/lib/entities/public-api.ts
@@ -9,6 +9,7 @@
  */
 export * from './entities.module';
 export * from './common';
+export * from './inst-repo.entity';
 export * from './journal_reference.entity';
 export * from './journal.entity';
 export * from './organization.entity';

--- a/projects/toco-lib/src/lib/search/query-input/query-input.component.ts
+++ b/projects/toco-lib/src/lib/search/query-input/query-input.component.ts
@@ -2,6 +2,31 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
+/**
+ * Represents a component used to search a query. 
+ * 
+ * In order to use this component with the correct i18n, you must include 
+ * (in your i18n translate files that are in the folder `assets\i18n`) 
+ * a translation key of name "TOCO_SEARCH_QUERY_INPUT" that contains 
+ * an object as value with the translation needed by this component. 
+ * 
+ * In the case of `es.json` file, you must include the following translation key: 
+    "TOCO_SEARCH_QUERY_INPUT": {
+        "INPUT_SEARCH_LABEL": "Buscar",
+        "INPUT_SEARCH_PLACEHOLDER": "Escriba un criterio y presione Enter",
+        "BUTTON_SEARCH": "Buscar"
+    }
+ * 
+ * In the case of `en.json` file, you must include the following translation key: 
+    "TOCO_SEARCH_QUERY_INPUT": {
+        "INPUT_SEARCH_LABEL": "Search",
+        "INPUT_SEARCH_PLACEHOLDER": "Write a phrase and press Enter",
+        "BUTTON_SEARCH": "Search"
+    }
+ * 
+ * If you have another language, then you have another `*.json` file, 
+ * and you must include the "TOCO_SEARCH_QUERY_INPUT" translation key with the correct translation values. 
+ */
 @Component({
   selector: 'toco-search-query-input',
   templateUrl: './query-input.component.html',

--- a/projects/toco-lib/src/lib/statics/statics.module.ts
+++ b/projects/toco-lib/src/lib/statics/statics.module.ts
@@ -1,5 +1,6 @@
 
 import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
 import { SharedModule } from '../shared/public-api';
 
 import { StaticChipsComponent } from './chips/chips-static.component';
@@ -14,7 +15,8 @@ import { StaticTextComponent } from './text/text-static.component';
 	],
 
 	imports: [
-		SharedModule
+		SharedModule,
+		ReactiveFormsModule
 	],
 
 	exports: [

--- a/projects/toco-lib/src/lib/statics/text/text-static.component.html
+++ b/projects/toco-lib/src/lib/statics/text/text-static.component.html
@@ -1,5 +1,5 @@
 
 <mat-form-field class="text-mat-form-field control-without-interactivity" [appearance]="appearance">
     <mat-label>{{ desc }}</mat-label>
-    <input matInput [value]="value ? value : 'There is not any text to show!'" [style.textAlign]="textAlign" [attr.aria-label]="desc" />
+    <input matInput [value]="value ? value : valueByDefault" [style.textAlign]="textAlign" [attr.aria-label]="desc" />
 </mat-form-field>

--- a/projects/toco-lib/src/lib/statics/text/text-static.component.html
+++ b/projects/toco-lib/src/lib/statics/text/text-static.component.html
@@ -1,5 +1,5 @@
 
 <mat-form-field class="text-mat-form-field control-without-interactivity" [appearance]="appearance">
     <mat-label>{{ desc }}</mat-label>
-    <input matInput [value]="value ? value : valueByDefault" [style.textAlign]="textAlign" [attr.aria-label]="desc" />
+    <input matInput [formControl]="input_static" [style.textAlign]="textAlign" [attr.aria-label]="desc" (input)="handleInput()" />
 </mat-form-field>

--- a/projects/toco-lib/src/lib/statics/text/text-static.component.scss
+++ b/projects/toco-lib/src/lib/statics/text/text-static.component.scss
@@ -2,7 +2,6 @@
 .text-mat-form-field
 {
     width: 100%;
-    //cursor: text;
 }
 
 /* Disables the interactivity. */

--- a/projects/toco-lib/src/lib/statics/text/text-static.component.ts
+++ b/projects/toco-lib/src/lib/statics/text/text-static.component.ts
@@ -1,5 +1,6 @@
 
-import { Component, Input } from '@angular/core';
+import { Component, OnInit, Input} from '@angular/core';
+import { FormControl } from '@angular/forms';
 
 /**
  * Represents a static control that shows a text. 
@@ -12,7 +13,7 @@ import { Component, Input } from '@angular/core';
         '[style.width]': 'width'
     }
 })
-export class StaticTextComponent
+export class StaticTextComponent implements OnInit
 {
     /**
      * The control's width. 
@@ -57,6 +58,13 @@ export class StaticTextComponent
 	@Input()
     public textAlign: string;
 
+	/**
+	 * Returns a reference to the `FormControl` that tracks the value and validity state 
+	 * of the internal control that contains the text input. 
+	 * For internal use only. 
+	 */
+	public input_static: FormControl;
+
 	public constructor()
 	{
 		this.width = '100%';
@@ -65,5 +73,25 @@ export class StaticTextComponent
 		this.value = undefined;
 		this.valueByDefault = 'There is not any text to show!';
 		this.textAlign = 'left';
+
+		this.input_static = undefined;
+	}
+
+    public ngOnInit(): void
+	{
+		if(this.value === undefined) this.value = this.valueByDefault;
+
+		this.input_static = new FormControl(this.value);
+	}
+
+	/**
+	 * Handler method that is called when the control's value changes in the UI. 
+	 * It is always used to set the `value` input field as the component value. 
+	 * For internal use only. 
+	 */
+	public handleInput(): void
+	{
+		/* It always sets the `value` input field as the component value. */
+		this.input_static.setValue(this.value);
 	}
 }

--- a/projects/toco-lib/src/lib/statics/text/text-static.component.ts
+++ b/projects/toco-lib/src/lib/statics/text/text-static.component.ts
@@ -7,10 +7,21 @@ import { Component, Input } from '@angular/core';
 @Component({
 	selector: 'static-text',
 	templateUrl: './text-static.component.html',
-	styleUrls: ['./text-static.component.scss']
+	styleUrls: ['./text-static.component.scss'],
+    host: {
+        '[style.width]': 'width'
+    }
 })
 export class StaticTextComponent
 {
+    /**
+     * The control's width. 
+     * The width of the content area, padding area or border area (depending on `box-sizing`) of certain boxes. 
+     * By default, its value is `'100%'`. 
+     */
+	@Input()
+	public width: string;
+
     /**
      * The control's appearance. 
      * By default, its value is `'outline'`. 
@@ -32,6 +43,13 @@ export class StaticTextComponent
 	@Input()
 	public value: string;
 
+	/**
+	 * The control's default value. 
+	 * By default, its value is `'There is not any text to show!'`. 
+	 */
+	@Input()
+	public valueByDefault: string;
+
     /**
      * Returns the control's text align. 
      * By default, its value is `'left'`. 
@@ -41,9 +59,11 @@ export class StaticTextComponent
 
 	public constructor()
 	{
+		this.width = '100%';
 		this.appearance = 'outline';
 		this.desc = undefined;
 		this.value = undefined;
+		this.valueByDefault = 'There is not any text to show!';
 		this.textAlign = 'left';
 	}
 }


### PR DESCRIPTION
**Información de cambios en el proyecto "toco-ng" con respecto a la tarea tarea "Adición de Repositorios al Catálogo de Sceiba"** 
 - Adicioné el validador "minLength" en el fichero "core\utils\validator.ts". 
    * El validador "minLength" es aplicado a los controles `FormArray` solamente. 
 - Adicioné el componente "DialogDeleteConfirmComponent" y el objeto "DialogDeleteConfirmMessageData" en el fichero "core\utils\message-handler.ts". 
    * El componente "DialogDeleteConfirmComponent" es usado para mostrar un mensaje de confirmación de diálogo cuando algo es borrado. 
    * El objeto "DialogDeleteConfirmMessageData" es usado para guardar los diferentes datos que son mostrados en el diálogo. 
 - Adicioné el tipo "ChildControlsPath" en el fichero "core\utils\helpers.ts". 
    * El tipo "ChildControlsPath" representa un objeto de caminos que es usado para obtener los controles hijos en un control "FormGroup" / "FormArray". El valor de sus propiedades es un valor de cadena delimitado por puntos que define el camino a un control hijo. 
 - Cree el fichero "entities\inst-repo.entity.ts" que contiene todo lo referente a las entidades usadas en "Repositorio Institucional". 
    * En el fichero se encuentran las clases "MainInstitution" y "InstitutionalRepository", esta última es la principal. 
    * En el fichero se encuentran los objetos globales constantes "mainInstEmpty" y "instRepoEmpty" que representan objetos con todos sus campos vacíos (ver detalles en el código fuente). Ellos son usados por el resolver "InstRepoResolverService" para resolver siempre el mismo objeto que se le pasa a la vista de adicionar un nuevo "Repositorio Institucional". 
 - Mejoré e incorporé nuevas características al componente "StaticTextComponent" que ya existía en la carpeta "statics\text". 
    * Además arreglé un error en el componente "StaticTextComponent": el usuario podía cambiar el valor del control y esto estaba mal porque es un control para mostrar el valor (static) y NO puede cambiarlo aquí. 
    * Los códigos fuentes que usan este componente NO fueron afectados. 
 - Mejoré la implementación del componente "DialogContentComponent" que ya existía en el fichero "core\utils\message-handler.ts". 
    * Los códigos fuentes que usan este componente NO fueron afectados. 
 - (Rafa mira lo que tuve que hacer) Comenté la línea: 
//throwIfAlreadyLoaded(parentModule, 'CoreModule')
en el constructor de la clase "CoreModule" porque NO me permitía hacer lazy-loading en el proyecto "catalog-ng".

**Pendientes en el proyecto "toco-ng" con respecto a la tarea tarea "Adición de Repositorios al Catálogo de Sceiba"**
 - (Ver con Rafa) Comenté la línea: 
//throwIfAlreadyLoaded(parentModule, 'CoreModule')
en el constructor de la clase "CoreModule" porque NO me permitía hacer lazy-loading en el proyecto "catalog-ng". Buscar otra posible solución para que el módulo "CoreModule" se cargue solamente una vez en un proyecto y a la vez me permita hacer lazy-loading. 
    * Posible solución: hacer lo que hace Angular cuando se importa el módulo `BrowserAnimationsModule` más de una vez. En este caso, Angular muestra el siguiente error: 
"Error: Uncaught (in promise): Error: BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor from a lazy loaded module, import CommonModule instead." 
Entonces el problema se soluciona importando el módulo "CommonModule" en lugar de importar otra vez el módulo `BrowserAnimationsModule`. 

**Información de cambios en el proyecto "toco-ng" con respecto a la tarea tarea "Translation for cuor-ng"**
 - Hice la traducción (i18n) del componente "AuthenticationComponent" que está en la carpeta "authentication". 

**Pendientes en el proyecto "toco-ng" con respecto a la tarea tarea "Translation for cuor-ng"**
